### PR TITLE
[bug] CORE-89 - Resolved issue with 0 byte files getting pulled into hotfolder...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target
 *.iws
+.project
+reach-engine-jpoller.ipr
+.classpath
+.settings
+bin/

--- a/reach-engine-jpoller.ipr
+++ b/reach-engine-jpoller.ipr
@@ -60,6 +60,7 @@
   <component name="GradleSettings">
     <option name="gradleHome" value="$GRADLE_HOME$" />
   </component>
+  <component name="IdProvider" IDEtalkID="9E074910FAED5E6CD04B3B76C731C325" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/src/main/java/org/sadun/util/polling/DirectoryPoller.java
+++ b/src/main/java/org/sadun/util/polling/DirectoryPoller.java
@@ -568,9 +568,10 @@ public class DirectoryPoller extends BaseSignalSourceThread implements Terminabl
 							boolean proceed = true;
 
 							// if hidden, skip
-							if (orig.isHidden()) {
+							if (orig.isHidden() || orig.length() == 0) {
 								failedToMoveCount++;
 								proceed = false;
+								continue;
 							}
 
 							if (logger.isDebugEnabled()) {
@@ -684,6 +685,9 @@ public class DirectoryPoller extends BaseSignalSourceThread implements Terminabl
 						} catch (FileNotFoundException e) {
 							notify(new ExceptionSignal(new AutomoveException(orig, dest, (new StringBuilder()).append("Could not verify lock on ").append(orig.getName()).toString()), this));
 							failedToMoveCount++;
+							if (logger.isWarnEnabled()) {
+								logger.warn("Unable to move file", e);
+							}
 							continue;
 						} catch (IOException e) {
 							notify(new ExceptionSignal(new AutomoveException(orig, dest, (new StringBuilder()).append("Tentative lock attempt failed on ").append(orig.getName()).toString()), this));


### PR DESCRIPTION
... workflows

@dlamy 
@leafknode 
- 0 byte files were getting picked up by the poller when several files were dragged into a watchfolder
- sometimes permissions issues were causing file not found exceptions which were getting swallowed up, now printing filenotfound exceptions to the logs if warn is enabled. 
